### PR TITLE
Add tqdm dep, increase job result timeout

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -25,8 +25,8 @@ results = mi.infer(
     column="TITLE",
     system_prompt=system_prompt,
     model="llama-3.1-8b",
+    json_schema=json_schema,
     job_priority=0,
-    stay_attached=True,
 )
 
 # jobs = mi.list_jobs()

--- a/materialized_intelligence/sdk.py
+++ b/materialized_intelligence/sdk.py
@@ -307,8 +307,8 @@ class MaterializedIntelligence:
                 # TODO: we implment retries in cases where the job hasn't written results yet
                 # it would be better if we could receive a fully succeeded status from the job
                 # and not have such a race condition
-                max_retries = 3
-                retry_delay = 1  # initial delay in seconds
+                max_retries = 20 # winds up being 100 seconds cumulative delay
+                retry_delay = 5 # initial delay in seconds
 
                 for _ in range(max_retries):
                     time.sleep(retry_delay)
@@ -321,12 +321,10 @@ class MaterializedIntelligence:
                     if job_results_response.status_code == 200:
                         break
 
-                    retry_delay *= 2  # exponential backoff
-
                 if job_results_response.status_code != 200:
                     spinner.write(
                         to_colored_text(
-                            "Failed to obtain job results. Please check the job status with `mi.get_job_status('{job_id}')`",
+                            "Job succeeded, but results are not yet available. Use `mi.get_job_results('{job_id}')` to obtain results.",
                             state="fail",
                         )
                     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ installer = "uv"
 
 [project]
 name = "materialized-intelligence"
-version = "0.1.3"
+version = "0.1.4"
 description = "Materialized Intelligence SDK"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -21,7 +21,8 @@ dependencies = [
     "polars==1.8.2",
     "click==8.1.7",
     "colorama==0.4.4",
-    "yaspin==3.1.0"
+    "yaspin==3.1.0",
+    "tqdm==4.67.1"
 ]
 
 [project.scripts]


### PR DESCRIPTION
@coopslarhette you made a good call pointing out that the timeout was too short. Ideally, we want to move to a state where the job only "succeeds" once the outputs are fully written, and have some sort of `POST-PROCESSING` state in the meantime. I'll open a ticket about this.