### PR TITLE
fix Exception type error

### DIFF
--- a/sutro/sdk.py
+++ b/sutro/sdk.py
@@ -983,7 +983,7 @@ class Sutro:
                 results_df = results_df.drop(
                     [output_column, "output_column_json_decoded"]
                 )
-            except json.JSONDecodeError:
+            except Exception as e:
                 # if the first row cannot be json decoded, do nothing
                 pass
 


### PR DESCRIPTION
Was not an issue with initial json decoding, but rather the casting to json with `json_decode`. So needed a different exception type.