### PR TITLE
use presigning to avoid moving data through both local and sutro remote servers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ dependencies = [
     "tqdm==4.67.1",
     "pydantic==2.11.4",
     "pyarrow==21.0.0",
+    "boto3==1.35.36", 
+    "botocore==1.35.36", 
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This pr makes a few changes to the infer method in the sdk.

If the user provides an s3-compatible URI it will attempt to make a presigned _read_ version of that uri and send it to the sutro api. If the user has raw data, it will get a presigned _upload_ uri from the sutro api and use that for uploading directly from the client.

