### PR TITLE
[batch_run_function] add langsmtih integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ installer = "uv"
 
 [project]
 name = "sutro"
-version = "0.1.56"
+version = "0.1.57"
 description = "Sutro Python SDK"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sutro/observability.py
+++ b/sutro/observability.py
@@ -1,53 +1,221 @@
 from typing import Optional, Dict, Any, List, Callable
 
+import json
+import logging
+import os
+import uuid
+from datetime import datetime, timezone
+
 import requests
-from langsmith import traceable, get_current_run_tree
+from langsmith import traceable, get_current_run_tree, Client
+
+logger = logging.getLogger(__name__)
 
 
-# TODO(cooper) expand this more or make it more ergonomic to use
-# with batch style results. Perhaps there is a more native way in LangSmith
-# to handle these?
-def _save_trace_to_langsmith(
+def _try_parse_json(value: Any, fallback_key: str) -> dict:
+    """Try to parse a value as JSON. If it's already a dict, return it.
+    If it's a JSON string, parse it. Otherwise wrap it in a dict."""
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+            if isinstance(parsed, dict):
+                return parsed
+        except (json.JSONDecodeError, ValueError):
+            pass
+    return {fallback_key: value}
+
+
+def _is_langsmith_tracing_enabled() -> bool:
+    """Check if LangSmith tracing is enabled via environment variable."""
+    return os.environ.get("LANGSMITH_TRACING", "").lower() == "true"
+
+
+def _create_batch_parent_trace(
     function_name: str,
-    result: dict,
+    job_id: str,
+    num_rows: int,
     langsmith_metadata: Optional[Dict[str, Any]] = None,
     langsmith_tags: Optional[List[str]] = None,
+) -> bool:
+    """
+    Create a parent LangSmith trace for a batch function job.
+
+    Called at job submission time so that an artifact is immediately visible
+    in LangSmith while the batch job is running. The trace is left open
+    (no end_time) until results are retrieved and child traces are added.
+
+    Returns True if the trace was created successfully.
+    """
+    if not _is_langsmith_tracing_enabled():
+        return False
+
+    try:
+        client = Client()
+
+        metadata = {
+            "ls_provider": "sutro",
+            "ls_model_name": function_name,
+            "ls_method": "traceable",
+            "sutro_job_id": job_id,
+        }
+        if langsmith_metadata:
+            metadata.update(langsmith_metadata)
+
+        kwargs = {
+            "name": "Sutro Batch Function",
+            "run_type": "chain",
+            "id": uuid.uuid4(),
+            "inputs": {
+                "function_name": function_name,
+                "num_rows": num_rows,
+                "job_id": job_id,
+            },
+            "extra": {"metadata": metadata},
+            "start_time": datetime.now(timezone.utc),
+        }
+        if langsmith_tags:
+            kwargs["tags"] = langsmith_tags
+
+        client.create_run(**kwargs)
+        return True
+    except Exception:
+        logger.warning(
+            "Failed to create LangSmith parent trace for batch job %s",
+            job_id,
+            exc_info=True,
+        )
+        return False
+
+
+def _find_batch_parent_trace(job_id: str) -> Optional[dict]:
+    """
+    Query LangSmith for a parent trace associated with this batch job_id.
+
+    Returns a dict with the parent run's id, metadata, and tags if found,
+    or None if tracing is disabled or no parent trace exists.
+    """
+    if not _is_langsmith_tracing_enabled():
+        return None
+
+    try:
+        client = Client()
+
+        project_name = os.environ.get("LANGSMITH_PROJECT", "default")
+        runs = list(
+            client.list_runs(
+                project_name=project_name,
+                filter=f'has(metadata, \'{{"sutro_job_id": "{job_id}"}}\')',
+                limit=1,
+            )
+        )
+
+        if not runs:
+            return None
+
+        parent_run = runs[0]
+        # If the parent trace already has an end_time, child traces were
+        # already logged on a previous get_job_results call — skip re-logging
+        if parent_run.end_time is not None:
+            return None
+
+        return {
+            "id": parent_run.id,
+            "metadata": parent_run.extra.get("metadata", {})
+            if parent_run.extra
+            else {},
+            "tags": parent_run.tags or [],
+        }
+    except Exception:
+        logger.warning(
+            "Failed to query LangSmith for batch parent trace for job %s",
+            job_id,
+            exc_info=True,
+        )
+        return None
+
+
+def _log_batch_child_traces(
+    job_id: str,
+    parent_trace: dict,
+    inputs: List[Any],
+    outputs: List[Any],
+    job_details: Optional[dict] = None,
 ):
     """
-    Log a single inference result to LangSmith as a trace (post-hoc). Intended to be
-    used with results from a batch style job.
-
-    Useful for logging batch results or results you already have in hand.
-    Latency will NOT reflect the real API call duration.
+    Create a child trace per row under the given parent trace, then mark
+    the parent trace as complete.
 
     Args:
-        function_name: The Function name (e.g. "clay-bert"). Used as ls_model_name.
-        result: A result dict from the /functions/run endpoint.
-        langsmith_metadata: Extra metadata merged into the trace.
-        langsmith_tags: Tags attached to the trace for filtering.
+        job_id: The Sutro batch job ID.
+        parent_trace: Dict returned by _find_batch_parent_trace with id, metadata, tags.
+        inputs: Per-row inputs from the batch results.
+        outputs: Per-row outputs from the batch results.
+        job_details: Optional job dict from GET /jobs/{job_id} with token counts.
     """
-    metadata = {
-        "ls_provider": "sutro",
-        "ls_model_name": function_name,
-    }
-    if langsmith_metadata:
-        metadata.update(langsmith_metadata)
+    try:
+        client = Client()
 
-    traceable_kwargs = {
-        "run_type": "llm",
-        "name": "Sutro Function",
-        "metadata": metadata,
-    }
-    if langsmith_tags:
-        traceable_kwargs["tags"] = langsmith_tags
+        parent_run_id = parent_trace["id"]
+        metadata = parent_trace["metadata"]
+        tags = parent_trace["tags"]
 
-    # Note: latency won't reflect the real time it took to process the request
-    @traceable(**traceable_kwargs)
-    def _log_result() -> dict:
-        _attach_run_metadata(result)
-        return result
+        now = datetime.now(timezone.utc)
 
-    _log_result()
+        # Compute per-row token estimates by splitting aggregate evenly
+        # since the only way to show total token count in Langsmith dashboard
+        # is via aggreagaing the child runs (batch rows) of the main parent trace
+        per_row_usage = None
+        num_rows = len(outputs)
+        if job_details and num_rows > 0:
+            total_input = job_details.get("input_tokens")
+            total_output = job_details.get("output_tokens")
+            if total_input is not None or total_output is not None:
+                per_row_usage = {}
+                if total_input is not None:
+                    per_row_usage["input_tokens"] = total_input // num_rows
+                if total_output is not None:
+                    per_row_usage["output_tokens"] = total_output // num_rows
+                if total_input is not None and total_output is not None:
+                    per_row_usage["total_tokens"] = (
+                        per_row_usage["input_tokens"] + per_row_usage["output_tokens"]
+                    )
+
+        for inp, out in zip(inputs, outputs):
+            parsed_inp = inp if isinstance(inp, dict) else {"input_data": inp}
+            parsed_out = _try_parse_json(out, "output")
+            child_metadata = dict(metadata)
+            if per_row_usage:
+                child_metadata["usage_metadata"] = per_row_usage
+            child_kwargs = {
+                "name": "Sutro Function",
+                "run_type": "llm",
+                "id": uuid.uuid4(),
+                "parent_run_id": parent_run_id,
+                "inputs": parsed_inp,
+                "outputs": parsed_out,
+                "start_time": now,
+                "end_time": now,
+                "extra": {"metadata": child_metadata},
+            }
+            if tags:
+                child_kwargs["tags"] = tags
+            client.create_run(**child_kwargs)
+
+        parent_outputs = {"job_id": job_id}
+
+        client.update_run(
+            parent_run_id,
+            end_time=now,
+            outputs=parent_outputs,
+        )
+    except Exception:
+        logger.warning(
+            "Failed to log LangSmith child traces for batch job %s",
+            job_id,
+            exc_info=True,
+        )
 
 
 def _traced_run(

--- a/sutro/observability.py
+++ b/sutro/observability.py
@@ -12,13 +12,17 @@ from langsmith import traceable, get_current_run_tree, Client
 logger = logging.getLogger(__name__)
 
 # Fixed namespace for deterministic child run IDs.
-# uuid5(SUTRO_NAMESPACE, f"{job_id}-{row_index}") produces the same UUID
-# at submission time and retrieval time, so no state needs to be stored.
 _SUTRO_NAMESPACE = uuid.UUID("f47ac10b-58cc-4372-a567-0e02b2c3d479")
 
 
-def _child_run_id(job_id: str, row_index: int) -> uuid.UUID:
+def _row_run_id(job_id: str, row_index: int) -> uuid.UUID:
+    """Deterministic UUID for a batch row trace."""
     return uuid.uuid5(_SUTRO_NAMESPACE, f"{job_id}-{row_index}")
+
+
+def _ts(dt: datetime) -> str:
+    """Format a datetime as a LangSmith dotted_order timestamp."""
+    return dt.strftime("%Y%m%dT%H%M%S%fZ")
 
 
 def _try_parse_json(value: Any, fallback_key: str) -> dict:
@@ -49,14 +53,13 @@ def _create_batch_traces(
     langsmith_tags: Optional[List[str]] = None,
 ) -> bool:
     """
-    Create a parent LangSmith trace and child traces for a batch function job.
+    Create one top-level LangSmith trace per row in a batch function job.
 
-    Called at job submission time so that traces are immediately visible in
-    LangSmith while the batch job is running. All traces are left open
-    (no end_time) until results are retrieved via _complete_batch_traces.
+    Each row gets its own independent trace (like run_function would produce),
+    linked by shared sutro_job_id metadata for filtering. Uses deterministic
+    UUIDs so traces can be updated with outputs at retrieval time.
 
-    Child traces use deterministic UUIDs based on job_id + row index so they
-    can be updated at retrieval time without storing any state.
+    Uses batch_ingest_runs for efficient bulk creation.
 
     Returns True if traces were created successfully.
     """
@@ -76,38 +79,32 @@ def _create_batch_traces(
             metadata.update(langsmith_metadata)
 
         now = datetime.now(timezone.utc)
-        parent_id = uuid.uuid4()
+        project_name = os.environ.get("LANGSMITH_PROJECT", "default")
 
-        parent_kwargs = {
-            "name": "Sutro Batch Function",
-            "run_type": "chain",
-            "id": parent_id,
-            "inputs": {
-                "function_name": function_name,
-                "num_rows": len(input_data),
-                "job_id": job_id,
-            },
-            "extra": {"metadata": metadata},
-            "start_time": now,
-        }
-        if langsmith_tags:
-            parent_kwargs["tags"] = langsmith_tags
+        logger.debug("[langsmith] Building %d trace dicts...", len(input_data))
 
-        client.create_run(**parent_kwargs)
-
+        runs = []
         for i, inp in enumerate(input_data):
-            child_kwargs = {
+            run_id = _row_run_id(job_id, i)
+            run_ts = _ts(now)
+            run = {
+                "id": str(run_id),
+                "session_name": project_name,
                 "name": "Sutro Function",
                 "run_type": "llm",
-                "id": _child_run_id(job_id, i),
-                "parent_run_id": parent_id,
                 "inputs": {"input_data": inp},
                 "extra": {"metadata": metadata},
-                "start_time": now,
+                "start_time": now.isoformat(),
+                "trace_id": str(run_id),
+                "dotted_order": f"{run_ts}{str(run_id)}",
             }
             if langsmith_tags:
-                child_kwargs["tags"] = langsmith_tags
-            client.create_run(**child_kwargs)
+                run["tags"] = langsmith_tags
+            runs.append(run)
+
+        logger.debug("[langsmith] Calling batch_ingest_runs for %d traces...", len(runs))
+        client.batch_ingest_runs(create=runs)
+        logger.debug("[langsmith] batch_ingest_runs returned")
 
         return True
     except Exception:
@@ -119,84 +116,67 @@ def _create_batch_traces(
         return False
 
 
-def _find_batch_parent_trace(job_id: str) -> Optional[dict]:
+def _has_open_batch_traces(job_id: str) -> bool:
     """
-    Query LangSmith for a parent trace associated with this batch job_id.
+    Check if open (incomplete) LangSmith traces exist for this batch job_id.
 
-    Returns a dict with the parent run's id, metadata, and tags if found,
-    or None if tracing is disabled or no parent trace exists.
+    Returns True if at least one open trace is found, False otherwise.
     """
     if not _is_langsmith_tracing_enabled():
-        return None
+        return False
 
     try:
         client = Client()
-
         project_name = os.environ.get("LANGSMITH_PROJECT", "default")
+
+        # Check just the first row's trace to see if it exists and is open
+        first_run_id = _row_run_id(job_id, 0)
         runs = list(
             client.list_runs(
                 project_name=project_name,
-                filter=f'and(has(metadata, \'{{"sutro_job_id": "{job_id}"}}\'), eq(name, "Sutro Batch Function"))',
+                run_ids=[str(first_run_id)],
                 limit=1,
             )
         )
 
         if not runs:
-            return None
+            return False
 
-        parent_run = runs[0]
-        # If the parent trace already has an end_time, child traces were
-        # already completed on a previous get_job_results call — skip
-        if parent_run.end_time is not None:
-            return None
-
-        return {
-            "id": parent_run.id,
-            "metadata": parent_run.extra.get("metadata", {})
-            if parent_run.extra
-            else {},
-            "tags": parent_run.tags or [],
-        }
+        # If it already has an end_time, traces were already completed
+        return runs[0].end_time is None
     except Exception:
         logger.warning(
-            "Failed to query LangSmith for batch parent trace for job %s",
+            "Failed to check LangSmith traces for batch job %s",
             job_id,
             exc_info=True,
         )
-        return None
+        return False
 
 
 def _complete_batch_traces(
     job_id: str,
-    parent_trace: dict,
     num_rows: int,
     outputs: List[Any],
     job_details: Optional[dict] = None,
 ):
     """
-    Update child traces with outputs and mark the parent trace as complete.
+    Update batch row traces with outputs and mark them as complete.
 
-    Child traces are identified by deterministic UUIDs matching those created
-    in _create_batch_traces. Only outputs and token usage are updated.
+    Uses deterministic UUIDs matching those created in _create_batch_traces.
+    Uses batch_ingest_runs for efficient bulk updates.
 
     Args:
         job_id: The Sutro batch job ID.
-        parent_trace: Dict returned by _find_batch_parent_trace.
-        num_rows: Total number of rows in the batch (used for deterministic IDs).
+        num_rows: Total number of rows in the batch.
         outputs: Per-row outputs from the batch results.
         job_details: Optional job dict from GET /jobs/{job_id} with token counts.
     """
-    from langsmith.utils import LangSmithConflictError
-
     try:
         client = Client()
 
-        metadata = parent_trace["metadata"]
         now = datetime.now(timezone.utc)
 
-        # Compute per-row token estimates by splitting aggregate evenly
-        # since the only way to show total token count in the LangSmith dashboard
-        # is via aggregating the child runs of the parent trace
+        # Compute per-row token estimates
         per_row_usage = None
         if job_details and num_rows > 0:
             total_input = job_details.get("input_tokens")
@@ -212,49 +192,31 @@ def _complete_batch_traces(
                         per_row_usage["input_tokens"] + per_row_usage["output_tokens"]
                     )
 
-        for i, out in enumerate(outputs):
-            parsed_out = _try_parse_json(out, "output")
-            child_metadata = dict(metadata)
-            if per_row_usage:
-                child_metadata["usage_metadata"] = per_row_usage
-            try:
-                client.update_run(
-                    _child_run_id(job_id, i),
-                    end_time=now,
-                    outputs=parsed_out,
-                    extra={"metadata": child_metadata},
-                )
-            except Exception as e:
-                if isinstance(e, LangSmithConflictError):
-                    continue  # Already completed, skip
-                logger.warning(
-                    "Failed to update LangSmith child trace %d for batch job %s",
-                    i,
-                    job_id,
-                    exc_info=True,
-                )
+        logger.debug("[langsmith] Building %d update dicts...", len(outputs))
 
-        # Always try to complete the parent, even if some children failed.
-        # The SDK may flush buffered child writes during this call, causing
-        # a 409 conflict from a *child* that masks the parent update. Retry
-        # a few times to work around this.
-        for attempt in range(3):
-            try:
-                client.update_run(
-                    parent_trace["id"],
-                    end_time=now,
-                    outputs={"job_id": job_id},
-                )
-                break
-            except Exception as e:
-                if isinstance(e, LangSmithConflictError):
-                    continue  # Likely a buffered child conflict, retry
-                logger.warning(
-                    "Failed to complete LangSmith parent trace for batch job %s",
-                    job_id,
-                    exc_info=True,
-                )
-                break
+        updates = []
+        for i, out in enumerate(outputs):
+            run_id = _row_run_id(job_id, i)
+            parsed_out = _try_parse_json(out, "output")
+            update = {
+                "id": str(run_id),
+                "trace_id": str(run_id),
+                "dotted_order": f"{_ts(now)}{str(run_id)}",
+                "outputs": parsed_out,
+                "end_time": now.isoformat(),
+            }
+            if per_row_usage:
+                update["extra"] = {
+                    "metadata": {
+                        "ls_method": "traceable",
+                        "usage_metadata": per_row_usage,
+                    }
+                }
+            updates.append(update)
+
+        logger.debug("[langsmith] Calling batch_ingest_runs for %d updates...", len(updates))
+        client.batch_ingest_runs(update=updates)
+        logger.debug("[langsmith] batch_ingest_runs (update) returned")
     except Exception:
         logger.warning(
             "Failed to complete LangSmith traces for batch job %s",

--- a/sutro/observability.py
+++ b/sutro/observability.py
@@ -107,12 +107,8 @@ def _create_batch_traces(
         logger.debug("[langsmith] batch_ingest_runs returned")
 
         return True
-    except Exception:
-        logger.warning(
-            "Failed to create LangSmith traces for batch job %s",
-            job_id,
-            exc_info=True,
-        )
+    except Exception as e:
+        print(f"Warning: Failed to create LangSmith traces for batch job {job_id}: {e}")
         return False
 
 
@@ -144,12 +140,8 @@ def _has_open_batch_traces(job_id: str) -> bool:
 
         # If it already has an end_time, traces were already completed
         return runs[0].end_time is None
-    except Exception:
-        logger.warning(
-            "Failed to check LangSmith traces for batch job %s",
-            job_id,
-            exc_info=True,
-        )
+    except Exception as e:
+        print(f"Warning: Failed to check LangSmith traces for batch job {job_id}: {e}")
         return False
 
 
@@ -217,12 +209,8 @@ def _complete_batch_traces(
         logger.debug("[langsmith] Calling batch_ingest_runs for %d updates...", len(updates))
         client.batch_ingest_runs(update=updates)
         logger.debug("[langsmith] batch_ingest_runs (update) returned")
-    except Exception:
-        logger.warning(
-            "Failed to complete LangSmith traces for batch job %s",
-            job_id,
-            exc_info=True,
-        )
+    except Exception as e:
+        print(f"Warning: Failed to complete LangSmith traces for batch job {job_id}: {e}")
 
 
 def _traced_run(

--- a/sutro/observability.py
+++ b/sutro/observability.py
@@ -11,6 +11,15 @@ from langsmith import traceable, get_current_run_tree, Client
 
 logger = logging.getLogger(__name__)
 
+# Fixed namespace for deterministic child run IDs.
+# uuid5(SUTRO_NAMESPACE, f"{job_id}-{row_index}") produces the same UUID
+# at submission time and retrieval time, so no state needs to be stored.
+_SUTRO_NAMESPACE = uuid.UUID("f47ac10b-58cc-4372-a567-0e02b2c3d479")
+
+
+def _child_run_id(job_id: str, row_index: int) -> uuid.UUID:
+    return uuid.uuid5(_SUTRO_NAMESPACE, f"{job_id}-{row_index}")
+
 
 def _try_parse_json(value: Any, fallback_key: str) -> dict:
     """Try to parse a value as JSON. If it's already a dict, return it.
@@ -32,21 +41,24 @@ def _is_langsmith_tracing_enabled() -> bool:
     return os.environ.get("LANGSMITH_TRACING", "").lower() == "true"
 
 
-def _create_batch_parent_trace(
+def _create_batch_traces(
     function_name: str,
     job_id: str,
-    num_rows: int,
+    input_data: List[dict],
     langsmith_metadata: Optional[Dict[str, Any]] = None,
     langsmith_tags: Optional[List[str]] = None,
 ) -> bool:
     """
-    Create a parent LangSmith trace for a batch function job.
+    Create a parent LangSmith trace and child traces for a batch function job.
 
-    Called at job submission time so that an artifact is immediately visible
-    in LangSmith while the batch job is running. The trace is left open
-    (no end_time) until results are retrieved and child traces are added.
+    Called at job submission time so that traces are immediately visible in
+    LangSmith while the batch job is running. All traces are left open
+    (no end_time) until results are retrieved via _complete_batch_traces.
 
-    Returns True if the trace was created successfully.
+    Child traces use deterministic UUIDs based on job_id + row index so they
+    can be updated at retrieval time without storing any state.
+
+    Returns True if traces were created successfully.
     """
     if not _is_langsmith_tracing_enabled():
         return False
@@ -63,26 +75,44 @@ def _create_batch_parent_trace(
         if langsmith_metadata:
             metadata.update(langsmith_metadata)
 
-        kwargs = {
+        now = datetime.now(timezone.utc)
+        parent_id = uuid.uuid4()
+
+        parent_kwargs = {
             "name": "Sutro Batch Function",
             "run_type": "chain",
-            "id": uuid.uuid4(),
+            "id": parent_id,
             "inputs": {
                 "function_name": function_name,
-                "num_rows": num_rows,
+                "num_rows": len(input_data),
                 "job_id": job_id,
             },
             "extra": {"metadata": metadata},
-            "start_time": datetime.now(timezone.utc),
+            "start_time": now,
         }
         if langsmith_tags:
-            kwargs["tags"] = langsmith_tags
+            parent_kwargs["tags"] = langsmith_tags
 
-        client.create_run(**kwargs)
+        client.create_run(**parent_kwargs)
+
+        for i, inp in enumerate(input_data):
+            child_kwargs = {
+                "name": "Sutro Function",
+                "run_type": "llm",
+                "id": _child_run_id(job_id, i),
+                "parent_run_id": parent_id,
+                "inputs": {"input_data": inp},
+                "extra": {"metadata": metadata},
+                "start_time": now,
+            }
+            if langsmith_tags:
+                child_kwargs["tags"] = langsmith_tags
+            client.create_run(**child_kwargs)
+
         return True
     except Exception:
         logger.warning(
-            "Failed to create LangSmith parent trace for batch job %s",
+            "Failed to create LangSmith traces for batch job %s",
             job_id,
             exc_info=True,
         )
@@ -106,7 +136,7 @@ def _find_batch_parent_trace(job_id: str) -> Optional[dict]:
         runs = list(
             client.list_runs(
                 project_name=project_name,
-                filter=f'has(metadata, \'{{"sutro_job_id": "{job_id}"}}\')',
+                filter=f'and(has(metadata, \'{{"sutro_job_id": "{job_id}"}}\'), eq(name, "Sutro Batch Function"))',
                 limit=1,
             )
         )
@@ -116,7 +146,7 @@ def _find_batch_parent_trace(job_id: str) -> Optional[dict]:
 
         parent_run = runs[0]
         # If the parent trace already has an end_time, child traces were
-        # already logged on a previous get_job_results call — skip re-logging
+        # already completed on a previous get_job_results call — skip
         if parent_run.end_time is not None:
             return None
 
@@ -136,38 +166,38 @@ def _find_batch_parent_trace(job_id: str) -> Optional[dict]:
         return None
 
 
-def _log_batch_child_traces(
+def _complete_batch_traces(
     job_id: str,
     parent_trace: dict,
-    inputs: List[Any],
+    num_rows: int,
     outputs: List[Any],
     job_details: Optional[dict] = None,
 ):
     """
-    Create a child trace per row under the given parent trace, then mark
-    the parent trace as complete.
+    Update child traces with outputs and mark the parent trace as complete.
+
+    Child traces are identified by deterministic UUIDs matching those created
+    in _create_batch_traces. Only outputs and token usage are updated.
 
     Args:
         job_id: The Sutro batch job ID.
-        parent_trace: Dict returned by _find_batch_parent_trace with id, metadata, tags.
-        inputs: Per-row inputs from the batch results.
+        parent_trace: Dict returned by _find_batch_parent_trace.
+        num_rows: Total number of rows in the batch (used for deterministic IDs).
         outputs: Per-row outputs from the batch results.
         job_details: Optional job dict from GET /jobs/{job_id} with token counts.
     """
+    from langsmith.utils import LangSmithConflictError
+
     try:
         client = Client()
 
-        parent_run_id = parent_trace["id"]
         metadata = parent_trace["metadata"]
-        tags = parent_trace["tags"]
-
         now = datetime.now(timezone.utc)
 
         # Compute per-row token estimates by splitting aggregate evenly
-        # since the only way to show total token count in Langsmith dashboard
-        # is via aggreagaing the child runs (batch rows) of the main parent trace
+        # since the only way to show total token count in the LangSmith dashboard
+        # is via aggregating the child runs of the parent trace
         per_row_usage = None
-        num_rows = len(outputs)
         if job_details and num_rows > 0:
             total_input = job_details.get("input_tokens")
             total_output = job_details.get("output_tokens")
@@ -182,37 +212,52 @@ def _log_batch_child_traces(
                         per_row_usage["input_tokens"] + per_row_usage["output_tokens"]
                     )
 
-        for inp, out in zip(inputs, outputs):
-            parsed_inp = inp if isinstance(inp, dict) else {"input_data": inp}
+        for i, out in enumerate(outputs):
             parsed_out = _try_parse_json(out, "output")
             child_metadata = dict(metadata)
             if per_row_usage:
                 child_metadata["usage_metadata"] = per_row_usage
-            child_kwargs = {
-                "name": "Sutro Function",
-                "run_type": "llm",
-                "id": uuid.uuid4(),
-                "parent_run_id": parent_run_id,
-                "inputs": parsed_inp,
-                "outputs": parsed_out,
-                "start_time": now,
-                "end_time": now,
-                "extra": {"metadata": child_metadata},
-            }
-            if tags:
-                child_kwargs["tags"] = tags
-            client.create_run(**child_kwargs)
+            try:
+                client.update_run(
+                    _child_run_id(job_id, i),
+                    end_time=now,
+                    outputs=parsed_out,
+                    extra={"metadata": child_metadata},
+                )
+            except Exception as e:
+                if isinstance(e, LangSmithConflictError):
+                    continue  # Already completed, skip
+                logger.warning(
+                    "Failed to update LangSmith child trace %d for batch job %s",
+                    i,
+                    job_id,
+                    exc_info=True,
+                )
 
-        parent_outputs = {"job_id": job_id}
-
-        client.update_run(
-            parent_run_id,
-            end_time=now,
-            outputs=parent_outputs,
-        )
+        # Always try to complete the parent, even if some children failed.
+        # The SDK may flush buffered child writes during this call, causing
+        # a 409 conflict from a *child* that masks the parent update. Retry
+        # a few times to work around this.
+        for attempt in range(3):
+            try:
+                client.update_run(
+                    parent_trace["id"],
+                    end_time=now,
+                    outputs={"job_id": job_id},
+                )
+                break
+            except Exception as e:
+                if isinstance(e, LangSmithConflictError):
+                    continue  # Likely a buffered child conflict, retry
+                logger.warning(
+                    "Failed to complete LangSmith parent trace for batch job %s",
+                    job_id,
+                    exc_info=True,
+                )
+                break
     except Exception:
         logger.warning(
-            "Failed to log LangSmith child traces for batch job %s",
+            "Failed to complete LangSmith traces for batch job %s",
             job_id,
             exc_info=True,
         )

--- a/sutro/sdk.py
+++ b/sutro/sdk.py
@@ -23,7 +23,12 @@ from sutro.common import (
     BASE_OUTPUT_COLOR,
 )
 from sutro.interfaces import JobStatus
-from sutro.observability import _traced_run
+from sutro.observability import (
+    _traced_run,
+    _create_batch_parent_trace,
+    _find_batch_parent_trace,
+    _log_batch_child_traces,
+)
 from sutro.templates.classification import ClassificationTemplates
 from sutro.templates.embed import EmbeddingTemplates
 from sutro.templates.evals import EvalTemplates
@@ -591,6 +596,8 @@ class Sutro(EmbeddingTemplates, ClassificationTemplates, EvalTemplates):
         stay_attached: bool = False,
         job_name: Optional[str] = None,
         description: Optional[str] = None,
+        langsmith_metadata: Optional[Dict[str, Any]] = None,
+        langsmith_tags: Optional[List[str]] = None,
     ):
         """
         Run a Sutro Function on a large table, dataframe, or file using batch processing.
@@ -598,6 +605,10 @@ class Sutro(EmbeddingTemplates, ClassificationTemplates, EvalTemplates):
         This is a convenience method for running batch inference with functions. All function
         batch jobs run as priority 1, please use for flex processing endpoint for smaller dataset
         sizes and a more real-time-like experience.
+
+        Automatically traces to LangSmith when LANGSMITH_TRACING=true is set, not a dry run and stay_attached=False.
+        A parent trace is created at job submission time, and child traces (one per row) are added when results
+        are retrieved via get_job_results().
 
         Args:
             name (str): The name of the Sutro Function to use.
@@ -609,11 +620,15 @@ class Sutro(EmbeddingTemplates, ClassificationTemplates, EvalTemplates):
             dry_run (bool, optional): If True, return cost estimates instead of running inference.
                 Defaults to False.
             stay_attached (bool, optional): If True, the SDK will stay attached to the job and
-                stream progress updates. Defaults to False.
+                stream progress updates. Not compatible with LangSmith tracing. Defaults to False.
             job_name (str, optional): A job name for experiment/metadata tracking purposes.
                 Defaults to None.
             description (str, optional): A job description for experiment/metadata tracking purposes.
                 Defaults to None.
+            langsmith_metadata (dict, optional): Additional metadata to attach to the LangSmith trace.
+                Only used when tracing is enabled.
+            langsmith_tags (list, optional): Tags to attach to the LangSmith trace for filtering.
+                Only used when tracing is enabled.
 
         Returns:
             str: The ID of the batch job.
@@ -642,7 +657,7 @@ class Sutro(EmbeddingTemplates, ClassificationTemplates, EvalTemplates):
                 "Parquet or CSV file"
             )
 
-        return self.infer(
+        job_id = self.infer(
             data=input_data,
             model=name,
             name=job_name,
@@ -653,6 +668,17 @@ class Sutro(EmbeddingTemplates, ClassificationTemplates, EvalTemplates):
             stay_attached=stay_attached,
             truncate_rows=False,
         )
+
+        if job_id and not dry_run and not stay_attached:
+            _create_batch_parent_trace(
+                function_name=name,
+                job_id=job_id,
+                num_rows=len(input_data),
+                langsmith_metadata=langsmith_metadata,
+                langsmith_tags=langsmith_tags,
+            )
+
+        return job_id
 
     def infer_per_model(
         self,
@@ -1071,6 +1097,14 @@ class Sutro(EmbeddingTemplates, ClassificationTemplates, EvalTemplates):
             num_columns = pq.read_table(file_path).num_columns
             contains_expected_columns = num_columns == expected_num_columns
 
+        # Check if a parent LangSmith trace exists for this job (created at
+        # submission time via batch_run_function). If so, we'll log child traces
+        # when results are fetched from the API.
+        parent_trace = _find_batch_parent_trace(job_id)
+        # If langsmith tracing is active for this job, ensure we fetch inputs
+        # for the child traces even if the caller didn't request them
+        fetch_include_inputs = include_inputs or (parent_trace is not None)
+
         if disable_cache == False and contains_expected_columns:
             with yaspin(
                 SPINNER,
@@ -1084,7 +1118,7 @@ class Sutro(EmbeddingTemplates, ClassificationTemplates, EvalTemplates):
         else:
             payload = {
                 "job_id": job_id,
-                "include_inputs": include_inputs,
+                "include_inputs": fetch_include_inputs,
                 "include_cumulative_logprobs": include_cumulative_logprobs,
             }
             with yaspin(
@@ -1109,6 +1143,19 @@ class Sutro(EmbeddingTemplates, ClassificationTemplates, EvalTemplates):
                     spinner.stop()
                     print(to_colored_text(e.response.json(), state="fail"))
                     return None
+
+            # Log child traces to LangSmith if a parent trace exists for this job
+            if parent_trace:
+                raw_inputs = response_data["results"].get("inputs", [])
+                raw_outputs = response_data["results"].get("outputs", [])
+                job_details = self._fetch_job(job_id)
+                _log_batch_child_traces(
+                    job_id=job_id,
+                    parent_trace=parent_trace,
+                    inputs=raw_inputs,
+                    outputs=raw_outputs,
+                    job_details=job_details,
+                )
 
             results_df = pl.DataFrame(response_data["results"])
 

--- a/sutro/sdk.py
+++ b/sutro/sdk.py
@@ -25,6 +25,7 @@ from sutro.common import (
 from sutro.interfaces import JobStatus
 from sutro.observability import (
     _traced_run,
+    _is_langsmith_tracing_enabled,
     _create_batch_traces,
     _has_open_batch_traces,
     _complete_batch_traces,
@@ -676,13 +677,19 @@ class Sutro(EmbeddingTemplates, ClassificationTemplates, EvalTemplates):
         )
 
         if job_id and not dry_run and not stay_attached:
-            _create_batch_traces(
+            traced = _create_batch_traces(
                 function_name=name,
                 job_id=job_id,
                 input_data=input_data,
                 langsmith_metadata=langsmith_metadata,
                 langsmith_tags=langsmith_tags,
             )
+            if traced:
+                print(
+                    to_colored_text(
+                        f"📊 LangSmith tracing enabled — {len(input_data):,} traces created for {job_id}"
+                    )
+                )
 
         return job_id
 
@@ -1163,6 +1170,7 @@ class Sutro(EmbeddingTemplates, ClassificationTemplates, EvalTemplates):
 
         # Complete LangSmith traces with outputs regardless of source is cache or API request
         if has_open_traces and raw_outputs is not None:
+            print(to_colored_text(f"📊 Completing LangSmith traces for {job_id}..."))
             job_details = self._fetch_job(job_id)
             _complete_batch_traces(
                 job_id=job_id,
@@ -1170,6 +1178,7 @@ class Sutro(EmbeddingTemplates, ClassificationTemplates, EvalTemplates):
                 outputs=raw_outputs,
                 job_details=job_details,
             )
+            print(to_colored_text(f"📊 LangSmith traces completed for {job_id}"))
 
             results_df = results_df.rename({"outputs": output_column})
 

--- a/sutro/sdk.py
+++ b/sutro/sdk.py
@@ -26,7 +26,7 @@ from sutro.interfaces import JobStatus
 from sutro.observability import (
     _traced_run,
     _create_batch_traces,
-    _find_batch_parent_trace,
+    _has_open_batch_traces,
     _complete_batch_traces,
 )
 from sutro.templates.classification import ClassificationTemplates
@@ -1097,10 +1097,10 @@ class Sutro(EmbeddingTemplates, ClassificationTemplates, EvalTemplates):
             num_columns = pq.read_table(file_path).num_columns
             contains_expected_columns = num_columns == expected_num_columns
 
-        # Check if a parent LangSmith trace exists for this job (created at
-        # submission time via batch_run_function). If so, we'll complete the
-        # child traces with outputs when results are fetched from the API.
-        parent_trace = _find_batch_parent_trace(job_id)
+        # Check if open LangSmith traces exist for this job (created at
+        # submission time via batch_run_function). If so, we'll complete
+        # them with outputs when results are fetched from the API.
+        has_traces = _has_open_batch_traces(job_id)
 
         if disable_cache == False and contains_expected_columns:
             with yaspin(
@@ -1141,13 +1141,12 @@ class Sutro(EmbeddingTemplates, ClassificationTemplates, EvalTemplates):
                     print(to_colored_text(e.response.json(), state="fail"))
                     return None
 
-            # Complete LangSmith child traces with outputs if parent trace exists
-            if parent_trace:
+            # Complete LangSmith traces with outputs if they exist
+            if has_traces:
                 raw_outputs = response_data["results"].get("outputs", [])
                 job_details = self._fetch_job(job_id)
                 _complete_batch_traces(
                     job_id=job_id,
-                    parent_trace=parent_trace,
                     num_rows=len(raw_outputs),
                     outputs=raw_outputs,
                     job_details=job_details,

--- a/sutro/sdk.py
+++ b/sutro/sdk.py
@@ -634,6 +634,12 @@ class Sutro(EmbeddingTemplates, ClassificationTemplates, EvalTemplates):
             str: The ID of the batch job.
         """
         # Convert DataFrames/files to list of dicts for function calls
+        if stay_attached and _is_langsmith_tracing_enabled():
+            raise ValueError(
+                "Attached mode is not compatablie with LangSmith tracing. "
+                "Please set one of stay_attached OR LANGSMITH_TRACING env var."
+            )
+
         if isinstance(data, pd.DataFrame):
             input_data = data.to_dict(orient="records")
         elif isinstance(data, pl.DataFrame):

--- a/sutro/sdk.py
+++ b/sutro/sdk.py
@@ -1090,28 +1090,37 @@ class Sutro(EmbeddingTemplates, ClassificationTemplates, EvalTemplates):
             Union[pl.DataFrame, pd.DataFrame]: The results as a DataFrame. By default, returns polars.DataFrame; when with_original_df is an instance of pandas.DataFrame, returns pandas.DataFrame.
         """
 
-        file_path = os.path.expanduser(f"~/.sutro/job-results/{job_id}.snappy.parquet")
+        cache_file_path = os.path.expanduser(
+            f"~/.sutro/job-results/{job_id}.snappy.parquet"
+        )
         expected_num_columns = 1 + include_inputs + include_cumulative_logprobs
-        contains_expected_columns = False
-        if os.path.exists(file_path):
-            num_columns = pq.read_table(file_path).num_columns
-            contains_expected_columns = num_columns == expected_num_columns
+        cached_contains_expected_columns = False
+        if os.path.exists(cache_file_path):
+            num_columns = pq.read_table(cache_file_path).num_columns
+            cached_contains_expected_columns = num_columns == expected_num_columns
 
         # Check if open LangSmith traces exist for this job (created at
         # submission time via batch_run_function). If so, we'll complete
-        # them with outputs when results are fetched from the API.
-        has_traces = _has_open_batch_traces(job_id)
+        # them with outputs once results are available.
+        has_open_traces = _has_open_batch_traces(job_id)
 
-        if disable_cache == False and contains_expected_columns:
+        raw_outputs = None
+        if not disable_cache and cached_contains_expected_columns:
             with yaspin(
                 SPINNER,
-                text=to_colored_text(f"Loading results from cache: {file_path}"),
+                text=to_colored_text(f"Loading results from cache: {cache_file_path}"),
                 color=BASE_OUTPUT_COLOR,
             ) as spinner:
-                results_df = pl.read_parquet(file_path)
+                results_df = pl.read_parquet(cache_file_path)
                 spinner.write(
                     to_colored_text("✔ Results loaded from cache", state="success")
                 )
+                if has_open_traces:
+                    raw_outputs = (
+                        results_df["outputs"].to_list()
+                        if "outputs" in results_df.columns
+                        else None
+                    )
         else:
             payload = {
                 "job_id": job_id,
@@ -1141,24 +1150,26 @@ class Sutro(EmbeddingTemplates, ClassificationTemplates, EvalTemplates):
                     print(to_colored_text(e.response.json(), state="fail"))
                     return None
 
-            # Complete LangSmith traces with outputs if they exist
-            if has_traces:
+            if has_open_traces:
                 raw_outputs = response_data["results"].get("outputs", [])
-                job_details = self._fetch_job(job_id)
-                _complete_batch_traces(
-                    job_id=job_id,
-                    num_rows=len(raw_outputs),
-                    outputs=raw_outputs,
-                    job_details=job_details,
-                )
 
             results_df = pl.DataFrame(response_data["results"])
+
+        # Complete LangSmith traces with outputs regardless of source is cache or API request
+        if has_open_traces and raw_outputs is not None:
+            job_details = self._fetch_job(job_id)
+            _complete_batch_traces(
+                job_id=job_id,
+                num_rows=len(raw_outputs),
+                outputs=raw_outputs,
+                job_details=job_details,
+            )
 
             results_df = results_df.rename({"outputs": output_column})
 
             if not disable_cache:
-                os.makedirs(os.path.dirname(file_path), exist_ok=True)
-                results_df.write_parquet(file_path, compression="snappy")
+                os.makedirs(os.path.dirname(cache_file_path), exist_ok=True)
+                results_df.write_parquet(cache_file_path, compression="snappy")
                 spinner.write(
                     to_colored_text("✔ Results saved to cache", state="success")
                 )

--- a/sutro/sdk.py
+++ b/sutro/sdk.py
@@ -25,9 +25,9 @@ from sutro.common import (
 from sutro.interfaces import JobStatus
 from sutro.observability import (
     _traced_run,
-    _create_batch_parent_trace,
+    _create_batch_traces,
     _find_batch_parent_trace,
-    _log_batch_child_traces,
+    _complete_batch_traces,
 )
 from sutro.templates.classification import ClassificationTemplates
 from sutro.templates.embed import EmbeddingTemplates
@@ -670,10 +670,10 @@ class Sutro(EmbeddingTemplates, ClassificationTemplates, EvalTemplates):
         )
 
         if job_id and not dry_run and not stay_attached:
-            _create_batch_parent_trace(
+            _create_batch_traces(
                 function_name=name,
                 job_id=job_id,
-                num_rows=len(input_data),
+                input_data=input_data,
                 langsmith_metadata=langsmith_metadata,
                 langsmith_tags=langsmith_tags,
             )
@@ -1098,12 +1098,9 @@ class Sutro(EmbeddingTemplates, ClassificationTemplates, EvalTemplates):
             contains_expected_columns = num_columns == expected_num_columns
 
         # Check if a parent LangSmith trace exists for this job (created at
-        # submission time via batch_run_function). If so, we'll log child traces
-        # when results are fetched from the API.
+        # submission time via batch_run_function). If so, we'll complete the
+        # child traces with outputs when results are fetched from the API.
         parent_trace = _find_batch_parent_trace(job_id)
-        # If langsmith tracing is active for this job, ensure we fetch inputs
-        # for the child traces even if the caller didn't request them
-        fetch_include_inputs = include_inputs or (parent_trace is not None)
 
         if disable_cache == False and contains_expected_columns:
             with yaspin(
@@ -1118,7 +1115,7 @@ class Sutro(EmbeddingTemplates, ClassificationTemplates, EvalTemplates):
         else:
             payload = {
                 "job_id": job_id,
-                "include_inputs": fetch_include_inputs,
+                "include_inputs": include_inputs,
                 "include_cumulative_logprobs": include_cumulative_logprobs,
             }
             with yaspin(
@@ -1144,15 +1141,14 @@ class Sutro(EmbeddingTemplates, ClassificationTemplates, EvalTemplates):
                     print(to_colored_text(e.response.json(), state="fail"))
                     return None
 
-            # Log child traces to LangSmith if a parent trace exists for this job
+            # Complete LangSmith child traces with outputs if parent trace exists
             if parent_trace:
-                raw_inputs = response_data["results"].get("inputs", [])
                 raw_outputs = response_data["results"].get("outputs", [])
                 job_details = self._fetch_job(job_id)
-                _log_batch_child_traces(
+                _complete_batch_traces(
                     job_id=job_id,
                     parent_trace=parent_trace,
-                    inputs=raw_inputs,
+                    num_rows=len(raw_outputs),
                     outputs=raw_outputs,
                     job_details=job_details,
                 )


### PR DESCRIPTION
- adds langsmith integration for batch_run_function that mostly matches the behavior run_function has
looks like this in the ui:

<img width="1043" height="1182" alt="Screenshot 2026-03-16 at 4 19 11 PM" src="https://github.com/user-attachments/assets/ea8d5ec5-ab9c-4da0-a8a1-16ba1f10f9e1" />
<img width="1861" height="180" alt="Screenshot 2026-03-16 at 4 19 26 PM" src="https://github.com/user-attachments/assets/6a046a46-3b8c-4982-b0d0-0322b6a3f533" />

- testing a large 100k row job now to make sure it doesn't break anything